### PR TITLE
Change numpy dependency to allow all versions

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ classifiers = [
     "Operating System :: OS Independent",
 ]
 dependencies = [
-    "numpy<2", # Pybullet has trouble with numpy 2.0
+    "numpy",
     "jax",
     "jaxlib",
     "qpax",


### PR DESCRIPTION
The pybullet incompatibility with numpy >= 2.0 seems to have been resolved in pybullet v3.2.7: https://github.com/bulletphysics/bullet3/issues/4649